### PR TITLE
Added alt_deployment script and document

### DIFF
--- a/code-deploy/alt_deployment
+++ b/code-deploy/alt_deployment
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Usage: copy this file to the instance and run it once, e.g. /bin/bash alt_deployment
+
+PROJECT_DIR=/home/ec2-user/fsdf-elvis
+APACHE_CONFIG_DIR=/home/ec2-user/apache-configuration
+HTTP_CONFIG_DIRECTORY=/etc/httpd/conf.d
+
+PROXY_FILE_NAME=proxies.conf
+PROXY_SOURCE=$APACHE_CONFIG_DIR/config/$PROXY_FILE_NAME
+PROXY_CONFIG_TARGET=$HTTP_CONFIG_DIRECTORY/$PROXY_FILE_NAME
+
+FSDF_SERVER_FILE_NAME=fsdf
+FSDF_SERVICE_NAME=fsdf
+FSDF_SERVICE_TARGET=/etc/init.d/$FSDF_SERVICE_NAME
+FSDF_SERVICE_SOURCE=$PROJECT_DIR/code-deploy/fsdf
+
+ELEVATION_CONFIG_FILE_NAME=elevation.conf
+ELEVATION_CONFIG_SOURCE=$APACHE_CONFIG_DIR/config/$ELEVATION_CONFIG_FILE_NAME
+ELEVATION_CONFIG_TARGET=$HTTP_CONFIG_DIRECTORY/$ELEVATION_CONFIG_FILE_NAME
+
+LOGROTATE_SOURCE_DIRECTORY=/home/ec2-user/apache-configuration/config/logrotate/
+LOGROTATE_TARGET_DIRECTORY=/etc/logrotate.d
+
+cd /home/ec2-user
+sudo yum update -y
+sudo curl --silent --location https://rpm.nodesource.com/setup_12.x | sudo bash -
+
+sudo yum -y install nodejs
+
+sudo yum install -y gcc-c++ make
+sudo yum install -y httpd
+sudo yum install -y git
+sudo npm install -g forever
+sudo npm install -g bower
+
+git clone https://github.com/GeoscienceAustralia/fsdf-elvis.git
+git clone https://github.com/GeoscienceAustralia/apache-configuration.git
+
+cd fsdf-elvis
+npm install
+bower install
+
+# Sets up Apache HTTP service
+sudo cp "$PROXY_SOURCE" "$HTTP_CONFIG_DIRECTORY"
+sudo cp "$ELEVATION_CONFIG_SOURCE" "$HTTP_CONFIG_DIRECTORY"
+
+# Sets up logging
+sudo cp -f "$LOGROTATE_SOURCE_DIRECTORY"* "$LOGROTATE_TARGET_DIRECTORY"
+
+# Creates a SYSV service and autostarts it
+sudo cp $FSDF_SERVICE_SOURCE /etc/init.d
+sudo chmod +x /etc/init.d/$FSDF_SERVICE_NAME
+sudo service fsdf start
+sudo chkconfig fsdf on
+
+# To make sure in the right directory
+cd /home/ec2-user/fsdf-elvis
+bower update
+
+# Copy static content to Apache
+sudo cp -rf dist/* /var/www/html
+
+sudo systemctl start httpd
+sudo systemctl enable httpd

--- a/documentation/alt_deployment.md
+++ b/documentation/alt_deployment.md
@@ -8,7 +8,7 @@ This document describes steps and resources required to deploy a new instance of
 
 1. Launch an EC2 instance. This deployment and the current production load were tested on the following EC2 instance (as of 15/12/2020): Amazon Linux 2, t3.medium, 20GiB. Attach the `FSDFInstanceRole` role and `sg-6e50290a` security group to the instance at launch time or after the launch (for the IAM role and security group see the `ga-elevation` account).
 
-2. Install Nessusagent. There are 2 options: a) manual installation or b) ussing SSM. For the latter an SSM role needs to be attached to the instance. As there is the `FSDFInstanceRole` role attached to the isntance, policies need to be added to the `FSDFInstanceRole` role if the SSM installation is used. See [Tenable Installation Guide](https://intranet.ga.gov.au/confluence/display/ARCHCOM/Tenable+Installation+Guide#TenableInstallationGuide-HowtoattachIAMRoletoEC2Instance.) and Tenable documentation.
+2. Install Nessusagent. There are 2 options: a) manual installation or b) ussing SSM. For the latter an SSM role needs to be attached to the instance. As there is the `FSDFInstanceRole` role attached to the isntance, policies need to be added to the `FSDFInstanceRole` role if the SSM installation is used. See [Tenable Installation Guide](https://intranet.ga.gov.au/confluence/display/ARCHCOM/Tenable+Installation+Guide) and Tenable documentation.
 
 3. Copy the `fsdf-elvis/code-deploy/alt_deployment` script to the instance.
 

--- a/documentation/alt_deployment.md
+++ b/documentation/alt_deployment.md
@@ -1,0 +1,21 @@
+# Alternative Deployment
+
+## Overview
+
+This document describes steps and resources required to deploy a new instance of elevation application/web site hosted on AWS/EC2.
+
+## Steps
+
+1. Launch an EC2 instance. This deployment and the current production load were tested on the following EC2 instance (as of 15/12/2020): Amazon Linux 2, t3.medium, 20GiB. Attach the `FSDFInstanceRole` role and `sg-6e50290a` security group to the instance at launch time or after the launch (for the IAM role and security group see the `ga-elevation` account).
+
+2. Install Nessusagent. There are 2 options: a) manual installation or b) ussing SSM. For the latter an SSM role needs to be attached to the instance. As there is the `FSDFInstanceRole` role attached to the isntance, policies need to be added to the `FSDFInstanceRole` role if the SSM installation is used. See [Tenable Installation Guide](https://intranet.ga.gov.au/confluence/display/ARCHCOM/Tenable+Installation+Guide#TenableInstallationGuide-HowtoattachIAMRoletoEC2Instance.) and Tenable documentation.
+
+3. Copy the `fsdf-elvis/code-deploy/alt_deployment` script to the instance.
+
+4. Run the script once, e.g. `/bin/bash alt_deployment`
+
+5. Add the `export ELEVATION_SERVICE_KEY_VALUE=token=*****` to the `~\.bash_profile`.
+
+6. If domain names other than `elevation.fsdf.org.au` or `elevation-dev.*` are used, edit the `/etc/httpd/conf.d/elevation.conf` file.
+
+7. Reboot the instance.


### PR DESCRIPTION
Added the alt_deployment script and document with instructions/steps on how to deploy a new instance of elevation application/web site using the latest versions in GA's GitHub repository. This reflects the recent work done on ELVIS (specifically elevation; manual deployment of ELVIS), and is a deployment workaround/alternative as the previously used scripts have issues and the approaches are different.